### PR TITLE
Blacklist IP's table as a parameter and ability to use custom DNS server for the tests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 PREFIX ?=          /opt/openresty
 LUA_LIB_DIR ?=     $(PREFIX)/lualib
 INSTALL ?= install
+DNS_SERVER_IP ?= 8.8.8.8
 
 .PHONY: all test install
 
@@ -11,5 +12,5 @@ install: all
 	$(INSTALL) lib/resolver/*.lua $(LUA_LIB_DIR)/resolver
 
 test: install
-	PATH=$(PREFIX)/nginx/sbin:$$PATH LUA_PATH="$(LUA_PATH);$(PREFIX)/lualib/?.lua;$(PREFIX)/nginx/lualib/?.lua;" prove -I../test-nginx/lib -r t
+	PATH=$(PREFIX)/nginx/sbin:$$PATH LUA_PATH="$(LUA_PATH);$(PREFIX)/lualib/?.lua;$(PREFIX)/nginx/lualib/?.lua;" DNS_SERVER_IP=$(DNS_SERVER_IP) prove -I../test-nginx/lib -r t
 

--- a/README.markdown
+++ b/README.markdown
@@ -155,7 +155,7 @@ To load the master library,
 
 master new
 ----------
-`syntax: local master, err = resolver_master:new(shared_dict_key, domain, nameservers [, min_ttl, max_ttl, dns_timeout])`
+`syntax: local master, err = resolver_master:new(shared_dict_key, domain, nameservers [, min_ttl, max_ttl, dns_timeout, blacklist])`
 
 Creates a new master instance. Returns the instance and an error string.
 If successful the error string will be `nil`.
@@ -179,6 +179,9 @@ The `dns_timeout` argument determines the maximum amount of time in seconds to w
 We also use this value to schedule future DNS queries (i.e. query a bit earlier than the TTL suggests to allow for potential lag up to the `dns_timeout` value when receiving the results).
 **Note:** this is _NOT_ the total timeout for all nameservers. The total time is calculated as `dns_timeout * 5` since we use the default `retrans` value in [resty.dns.resolver:new](https://github.com/openresty/lua-resty-dns#new).
 The default value is `2`.
+
+The `blacklist` argument specifies table of banned IP addresses which are ignored if included in DNS server response.
+The default value is `{"127.0.0.1"}`.
 
 The master instance is thread safe and can be safely shared globally (typically declared as a global in a [init_by_lua_block](https://github.com/openresty/lua-nginx-module#init_by_lua_block)).
 

--- a/t/client.t
+++ b/t/client.t
@@ -73,11 +73,13 @@ no hosts available
 
 
 === TEST 4: catch expired hosts error
+--- main_config
+    env DNS_SERVER_IP=8.8.8.8;
 --- http_config
     lua_shared_dict test_res 1m;
     init_by_lua_block {
         local resolver_master = require "resolver.master"
-        local goog_master = resolver_master:new("test_res", "google.com", {"8.8.8.8"})
+        local goog_master = resolver_master:new("test_res", "google.com", {os.getenv("DNS_SERVER_IP")})
         goog_master:set({
             {
                 address = "17.0.0.1",
@@ -105,11 +107,13 @@ all hosts expired
 
 
 === TEST 5: get an address
+--- main_config
+    env DNS_SERVER_IP=8.8.8.8;
 --- http_config
     lua_shared_dict test_res 1m;
     init_by_lua_block {
         local resolver_master = require "resolver.master"
-        local goog_master = resolver_master:new("test_res", "google.com", {"8.8.8.8"})
+        local goog_master = resolver_master:new("test_res", "google.com", {os.getenv("DNS_SERVER_IP")})
         goog_master:set({
             {
                 address = "17.0.0.1",
@@ -137,11 +141,13 @@ all hosts expired
 
 
 === TEST 6: get stale address
+--- main_config
+    env DNS_SERVER_IP=8.8.8.8;
 --- http_config
     lua_shared_dict test_res 1m;
     init_by_lua_block {
         local resolver_master = require "resolver.master"
-        local goog_master = resolver_master:new("test_res", "google.com", {"8.8.8.8"})
+        local goog_master = resolver_master:new("test_res", "google.com", {os.getenv("DNS_SERVER_IP")})
         goog_master:set({
             {
                 address = "17.0.0.1",
@@ -169,11 +175,13 @@ all hosts expired
 
 
 === TEST 7: get round-robin
+--- main_config
+    env DNS_SERVER_IP=8.8.8.8;
 --- http_config
     lua_shared_dict test_res 1m;
     init_by_lua_block {
         local resolver_master = require "resolver.master"
-        local goog_master = resolver_master:new("test_res", "google.com", {"8.8.8.8"})
+        local goog_master = resolver_master:new("test_res", "google.com", {os.getenv("DNS_SERVER_IP")})
         goog_master:set({
             {
                 address = "17.0.0.1",
@@ -224,11 +232,13 @@ all hosts expired
 
 
 === TEST 8: skip expired
+--- main_config
+    env DNS_SERVER_IP=8.8.8.8;
 --- http_config
     lua_shared_dict test_res 1m;
     init_by_lua_block {
         local resolver_master = require "resolver.master"
-        local goog_master = resolver_master:new("test_res", "google.com", {"8.8.8.8"})
+        local goog_master = resolver_master:new("test_res", "google.com", {os.getenv("DNS_SERVER_IP")})
         local exp_offset = ngx.now() - 30
         goog_master:set({
             {
@@ -268,11 +278,13 @@ all hosts expired
 
 
 === TEST 9: select least expired
+--- main_config
+    env DNS_SERVER_IP=8.8.8.8;
 --- http_config
     lua_shared_dict test_res 1m;
     init_by_lua_block {
         local resolver_master = require "resolver.master"
-        local goog_master = resolver_master:new("test_res", "google.com", {"8.8.8.8"})
+        local goog_master = resolver_master:new("test_res", "google.com", {os.getenv("DNS_SERVER_IP")})
         local exp_offset = ngx.now() - 30
         goog_master:set({
             {
@@ -312,11 +324,13 @@ all hosts expired
 
 
 === TEST 10: obey ttl for re-sync
+--- main_config
+    env DNS_SERVER_IP=8.8.8.8;
 --- http_config
     lua_shared_dict test_res 1m;
     init_by_lua_block {
         local resolver_master = require "resolver.master"
-        goog_master = resolver_master:new("test_res", "google.com", {"8.8.8.8"}, 1)
+        goog_master = resolver_master:new("test_res", "google.com", {os.getenv("DNS_SERVER_IP")}, 1)
         goog_master:set({
             {
                 address = "17.0.0.1",
@@ -361,11 +375,13 @@ all hosts expired
 
 
 === TEST 11: don't wipe stale local entries on failed re-sync
+--- main_config
+    env DNS_SERVER_IP=8.8.8.8;
 --- http_config
     lua_shared_dict test_res 1m;
     init_by_lua_block {
         local resolver_master = require "resolver.master"
-        goog_master = resolver_master:new("test_res", "google.com", {"8.8.8.8"}, 1)
+        goog_master = resolver_master:new("test_res", "google.com", {os.getenv("DNS_SERVER_IP")}, 1)
         goog_master:set({
             {
                 address = "17.0.0.1",
@@ -409,11 +425,13 @@ nil
 
 
 === TEST 12: sync picks up changes
+--- main_config
+    env DNS_SERVER_IP=8.8.8.8;
 --- http_config
     lua_shared_dict test_res 1m;
     init_by_lua_block {
         local resolver_master = require "resolver.master"
-        goog_master = resolver_master:new("test_res", "google.com", {"8.8.8.8"}, 1)
+        goog_master = resolver_master:new("test_res", "google.com", {os.getenv("DNS_SERVER_IP")}, 1)
         goog_master:set({
             {
                 address = "17.0.0.1",

--- a/t/master.t
+++ b/t/master.t
@@ -277,9 +277,9 @@ max_ttl must >= min_ttl (10)
     location /t {
         content_by_lua_block {
             local resolver_master = require "resolver.master"
-            local goog_master, err = resolver_master:new("test_res", "google.com", {"" .. os.getenv("DNS_SERVER_IP")}, 10, 30, 0)
+            local goog_master, err = resolver_master:new("test_res", "google.com", {os.getenv("DNS_SERVER_IP")}, 10, 30, 0)
             ngx.say(err)
-            goog_master, err = resolver_master:new("test_res", "google.com", {"" .. os.getenv("DNS_SERVER_IP")}, 10, 30, -1)
+            goog_master, err = resolver_master:new("test_res", "google.com", {os.getenv("DNS_SERVER_IP")}, 10, 30, -1)
             ngx.say(err)
         }
     }

--- a/t/master.t
+++ b/t/master.t
@@ -8,11 +8,13 @@ __DATA__
 
 
 === TEST 1: manual hosts
+--- main_config
+    env DNS_SERVER_IP=8.8.8.8;
 --- http_config
     lua_shared_dict test_res 1m;
     init_by_lua_block {
         local resolver_master = require "resolver.master"
-        local goog_master = resolver_master:new("test_res", "google.com", {"8.8.8.8"})
+        local goog_master = resolver_master:new("test_res", "google.com", {os.getenv("DNS_SERVER_IP")})
         goog_master:set({
             {
                 address = "17.0.0.1",
@@ -39,14 +41,16 @@ google.com_17.0.0.1
 
 
 === TEST 2: query hosts
+--- main_config
+    env DNS_SERVER_IP=8.8.8.8;
 --- http_config
     lua_shared_dict test_res 1m;
     init_by_lua_block {
         local resolver_master = require "resolver.master"
-        goog_master = resolver_master:new("test_res", "google.com", {"8.8.8.8"}, 10, 30)
+        goog_master = resolver_master:new("test_res", "google.com", {os.getenv("DNS_SERVER_IP")}, 10, 30)
     }
     init_worker_by_lua_block {
-        goog_master:init()   
+        goog_master:init()
     }
 --- config
     location /t {
@@ -72,11 +76,13 @@ google.com_17.0.0.1
 
 
 === TEST 3: multiple inits single master
+--- main_config
+    env DNS_SERVER_IP=8.8.8.8;
 --- http_config
     lua_shared_dict test_res 1m;
     init_by_lua_block {
         local resolver_master = require "resolver.master"
-        goog_master = resolver_master:new("test_res", "google.com", {"8.8.8.8"}, 10, 30)
+        goog_master = resolver_master:new("test_res", "google.com", {os.getenv("DNS_SERVER_IP")}, 10, 30)
     }
     init_worker_by_lua_block {
         for i = 1,10 do
@@ -105,13 +111,15 @@ google.com_17.0.0.1
 
 
 === TEST 4: multiple inits multiple masters
+--- main_config
+    env DNS_SERVER_IP=8.8.8.8;
 --- http_config
     lua_shared_dict test_res 1m;
     init_by_lua_block {
         local resolver_master = require "resolver.master"
-        goog_master_a = resolver_master:new("test_res", "google.com", {"8.8.8.8"}, 10, 30)
-        goog_master_b = resolver_master:new("test_res", "google.com", {"8.8.8.8"}, 10, 30)
-        goog_master_c = resolver_master:new("test_res", "google.com", {"8.8.8.8"}, 10, 30)
+        goog_master_a = resolver_master:new("test_res", "google.com", {os.getenv("DNS_SERVER_IP")}, 10, 30)
+        goog_master_b = resolver_master:new("test_res", "google.com", {os.getenv("DNS_SERVER_IP")}, 10, 30)
+        goog_master_c = resolver_master:new("test_res", "google.com", {os.getenv("DNS_SERVER_IP")}, 10, 30)
     }
     init_worker_by_lua_block {
         for i = 1,10 do
@@ -142,11 +150,13 @@ google.com_17.0.0.1
 
 
 === TEST 5: filter banned ip's
+--- main_config
+    env DNS_SERVER_IP=8.8.8.8;
 --- http_config
     lua_shared_dict test_res 1m;
     init_by_lua_block {
         local resolver_master = require "resolver.master"
-        local goog_master = resolver_master:new("test_res", "google.com", {"8.8.8.8"})
+        local goog_master = resolver_master:new("test_res", "google.com", {os.getenv("DNS_SERVER_IP")})
         goog_master:set({
             {
                 address = "17.0.0.1",
@@ -181,15 +191,17 @@ google.com_17.0.0.1
 
 
 === TEST 6: catch shared dict init problems
+--- main_config
+    env DNS_SERVER_IP=8.8.8.8;
 --- http_config
     lua_shared_dict test_res 1m;
 --- config
     location /t {
         content_by_lua_block {
             local resolver_master = require "resolver.master"
-            local goog_master, err = resolver_master:new(nil, "google.com", {"8.8.8.8"})
+            local goog_master, err = resolver_master:new(nil, "google.com", {os.getenv("DNS_SERVER_IP")})
             ngx.say(err)
-            goog_master, err = resolver_master:new("bad_key", "google.com", {"8.8.8.8"})
+            goog_master, err = resolver_master:new("bad_key", "google.com", {os.getenv("DNS_SERVER_IP")})
             ngx.say(err)
         }
     }
@@ -203,17 +215,19 @@ missing shared_dict_key
 
 
 === TEST 7: catch domain init problems
+--- main_config
+    env DNS_SERVER_IP=8.8.8.8;
 --- http_config
     lua_shared_dict test_res 1m;
 --- config
     location /t {
         content_by_lua_block {
             local resolver_master = require "resolver.master"
-            local goog_master, err = resolver_master:new("test_res", nil, {"8.8.8.8"})
+            local goog_master, err = resolver_master:new("test_res", nil, {os.getenv("DNS_SERVER_IP")})
             ngx.say(err)
-            goog_master, err = resolver_master:new("test_res", "", {"8.8.8.8"})
+            goog_master, err = resolver_master:new("test_res", "", {os.getenv("DNS_SERVER_IP")})
             ngx.say(err)
-            goog_master, err = resolver_master:new("test_res", "  ", {"8.8.8.8"})
+            goog_master, err = resolver_master:new("test_res", "  ", {os.getenv("DNS_SERVER_IP")})
             ngx.say(err)
         }
     }
@@ -228,17 +242,19 @@ missing domain
 
 
 === TEST 8: catch min / max ttl init problems
+--- main_config
+    env DNS_SERVER_IP=8.8.8.8;
 --- http_config
     lua_shared_dict test_res 1m;
 --- config
     location /t {
         content_by_lua_block {
             local resolver_master = require "resolver.master"
-            local goog_master, err = resolver_master:new("test_res", "google.com", {"8.8.8.8"}, 0, 30)
+            local goog_master, err = resolver_master:new("test_res", "google.com", {os.getenv("DNS_SERVER_IP")}, 0, 30)
             ngx.say(err)
-            goog_master, err = resolver_master:new("test_res", "google.com", {"8.8.8.8"}, -1, 30)
+            goog_master, err = resolver_master:new("test_res", "google.com", {os.getenv("DNS_SERVER_IP")}, -1, 30)
             ngx.say(err)
-            goog_master, err = resolver_master:new("test_res", "google.com", {"8.8.8.8"}, 10, 9)
+            goog_master, err = resolver_master:new("test_res", "google.com", {os.getenv("DNS_SERVER_IP")}, 10, 9)
             ngx.say(err)
         }
     }
@@ -253,15 +269,17 @@ max_ttl must >= min_ttl (10)
 
 
 === TEST 9: catch dns_timeout init problems
+--- main_config
+    env DNS_SERVER_IP=8.8.8.8;
 --- http_config
     lua_shared_dict test_res 1m;
 --- config
     location /t {
         content_by_lua_block {
             local resolver_master = require "resolver.master"
-            local goog_master, err = resolver_master:new("test_res", "google.com", {"8.8.8.8"}, 10, 30, 0)
+            local goog_master, err = resolver_master:new("test_res", "google.com", {"" .. os.getenv("DNS_SERVER_IP")}, 10, 30, 0)
             ngx.say(err)
-            goog_master, err = resolver_master:new("test_res", "google.com", {"8.8.8.8"}, 10, 30, -1)
+            goog_master, err = resolver_master:new("test_res", "google.com", {"" .. os.getenv("DNS_SERVER_IP")}, 10, 30, -1)
             ngx.say(err)
         }
     }
@@ -304,7 +322,7 @@ missing nameservers
         goog_master = resolver_master:new("test_res", "google.com", {"127.0.0.1"}, 10, 30)
     }
     init_worker_by_lua_block {
-        goog_master:init()   
+        goog_master:init()
     }
 --- config
     location /t {
@@ -325,7 +343,7 @@ resolver master failed to query DNS for domain 'google.com'
         goog_master = resolver_master:new("test_res", "google.com", {{"boom", 0}}, 10, 30)
     }
     init_worker_by_lua_block {
-        goog_master:init()   
+        goog_master:init()
     }
 --- config
     location /t {
@@ -339,14 +357,16 @@ resolver master failed to create resty.dns.resolver for domain 'google.com'
 
 
 === TEST 13: backup nameserver
+--- main_config
+    env DNS_SERVER_IP=8.8.8.8;
 --- http_config
     lua_shared_dict test_res 1m;
     init_by_lua_block {
         local resolver_master = require "resolver.master"
-        goog_master = resolver_master:new("test_res", "google.com", {"127.0.0.1","8.8.8.8"}, 1, 1)
+        goog_master = resolver_master:new("test_res", "google.com", {"127.0.0.1",os.getenv("DNS_SERVER_IP")}, 1, 1)
     }
     init_worker_by_lua_block {
-        goog_master:init()   
+        goog_master:init()
     }
 --- config
     location /t {
@@ -373,14 +393,16 @@ resolver master failed to query DNS for domain 'google.com'
 
 
 === TEST 14: bogus domain alerts
+--- main_config
+    env DNS_SERVER_IP=8.8.8.8;
 --- http_config
     lua_shared_dict test_res 1m;
     init_by_lua_block {
         local resolver_master = require "resolver.master"
-        goog_master = resolver_master:new("test_res", "iam.notreal.fake", {"8.8.8.8"}, 10, 30)
+        goog_master = resolver_master:new("test_res", "iam.notreal.fake", {os.getenv("DNS_SERVER_IP")}, 10, 30)
     }
     init_worker_by_lua_block {
-        goog_master:init()   
+        goog_master:init()
     }
 --- config
     location /t {
@@ -394,12 +416,14 @@ resolver master failed to resolve domain 'iam.notreal.fake'
 
 
 === TEST 15: failed init
+--- main_config
+    env DNS_SERVER_IP=8.8.8.8;
 --- http_config
     lua_max_pending_timers 1;
     lua_shared_dict test_res 1m;
     init_by_lua_block {
         local resolver_master = require "resolver.master"
-        goog_master = resolver_master:new("test_res", "google.com", {"8.8.8.8"}, 10, 30)
+        goog_master = resolver_master:new("test_res", "google.com", {os.getenv("DNS_SERVER_IP")}, 10, 30)
     }
     init_worker_by_lua_block {
         ngx.timer.at(30, function() return true end)
@@ -419,16 +443,18 @@ too many pending timers
 
 
 === TEST 16: unable to schedule resolve alerts
+--- main_config
+    env DNS_SERVER_IP=8.8.8.8;
 --- http_config
     lua_max_pending_timers 2;
     lua_shared_dict test_res 1m;
     init_by_lua_block {
         local resolver_master = require "resolver.master"
-        goog_master = resolver_master:new("test_res", "google.com", {"8.8.8.8"}, 2, 2)
+        goog_master = resolver_master:new("test_res", "google.com", {os.getenv("DNS_SERVER_IP")}, 2, 2)
     }
     init_worker_by_lua_block {
-        ngx.timer.at(0, function() 
-            ngx.timer.at(0, function() 
+        ngx.timer.at(0, function()
+            ngx.timer.at(0, function()
                 ngx.timer.at(30, function() return true end)
                 ngx.timer.at(30, function() return true end)
             end)
@@ -447,11 +473,13 @@ resolver master failed to create resolve timer for domain 'google.com'
 
 
 === TEST 17: obey min / max ttl
+--- main_config
+    env DNS_SERVER_IP=8.8.8.8;
 --- http_config
     lua_shared_dict test_res 1m;
     init_by_lua_block {
         local resolver_master = require "resolver.master"
-        local goog_master = resolver_master:new("test_res", "google.com", {"8.8.8.8"}, 10, 30)
+        local goog_master = resolver_master:new("test_res", "google.com", {os.getenv("DNS_SERVER_IP")}, 10, 30)
         goog_master:set({
             {
                 address = "17.0.0.1",
@@ -488,20 +516,22 @@ google.com_17.0.0.3=1482624010
 
 
 === TEST 18: next resolve time
+--- main_config
+    env DNS_SERVER_IP=8.8.8.8;
 --- http_config
     lua_shared_dict test_res 1m;
     init_by_lua_block {
         local resolver_master = require "resolver.master"
-        goog_master = resolver_master:new("test_res", "google.com", {"8.8.8.8"}, 10, 30, 2)
+        goog_master = resolver_master:new("test_res", "google.com", {os.getenv("DNS_SERVER_IP")}, 10, 30, 2)
     }
 --- config
     location /t {
         content_by_lua_block {
-            ngx.say(goog_master:set({{ 
+            ngx.say(goog_master:set({{
                 address = "17.0.0.1",
                 ttl = 300
             }}))
-            ngx.say(goog_master:set({{ 
+            ngx.say(goog_master:set({{
                 address = "17.0.0.1",
                 ttl = 0
             }}))
@@ -531,3 +561,46 @@ google.com_17.0.0.3=1482624010
 [error]
 
 
+=== TEST 19: filter banned 127.0.53.53 and 127.0.0.1 ip's
+--- main_config
+    env DNS_SERVER_IP=8.8.8.8;
+--- http_config
+    lua_shared_dict test_res 1m;
+    init_by_lua_block {
+        local resolver_master = require "resolver.master"
+        local goog_master = resolver_master:new("test_res", "google.com", {os.getenv("DNS_SERVER_IP")}, nil, nil, nil, {"127.0.0.1", "127.0.53.53"})
+        goog_master:set({
+            {
+                address = "17.0.0.1",
+                ttl = 300
+            },
+            {
+                address = "127.0.0.1", -- banned
+                ttl = 300
+            },
+            {
+                address = "127.0.53.53", -- banned
+                ttl = 300
+            },
+        }, 1482624000)
+    }
+--- config
+    location /t {
+        content_by_lua_block {
+            local keys = ngx.shared.test_res:get_keys()
+            for i, k in ipairs(keys) do
+                local v, err = ngx.shared.test_res:get(k)
+                if v ~= "_master_" then
+                    ngx.say(k)
+                    ngx.say(v)
+                end
+            end
+        }
+    }
+--- request
+    GET /t
+--- response_body
+google.com_17.0.0.1
+1482624300
+--- no_error_log
+[error]


### PR DESCRIPTION
This PR is intended to provide configurable table of blacklisted IP addresses and ability to use DNS server IP different from 8.8.8.8 for the tests (via DNS_SERVER_IP environment variable).