### PR TITLE
Schedule the resolver function even if the resty resolver fails

### DIFF
--- a/lib/resolver/master.lua
+++ b/lib/resolver/master.lua
@@ -30,6 +30,7 @@ resolve = function(master)
     })
     if not res then
         ngx.log(ngx.CRIT, "resolver master failed to create resty.dns.resolver for domain '", master._domain, "': ", err)
+        schedule(master, master._min_ttl)
         return
     end
 


### PR DESCRIPTION
Fixes #23 

While there might be scenarios where openresty resolver creation will constantly fail, I would consider retrying to be a more robust response to failures to create the openresty resolver since it will mean that temporary failures to create the resolver will eventually be fixed.

I haven't added any extra parameters around timeouts/backoffs because I suspect this will be a rare enough code path that the simple retry based on the min_ttl is sufficient.